### PR TITLE
FormExtension.php: TwigRendererInterface to FormRendererInterface

### DIFF
--- a/Twig/Extension/FormExtension.php
+++ b/Twig/Extension/FormExtension.php
@@ -12,7 +12,7 @@
 namespace Genemu\Bundle\FormBundle\Twig\Extension;
 
 use Symfony\Component\Form\FormView;
-use Symfony\Bridge\Twig\Form\TwigRendererInterface;
+use Symfony\Component\Form\FormRendererInterface;
 use Twig\Extension\AbstractExtension;
 
 /**
@@ -35,7 +35,7 @@ class FormExtension extends AbstractExtension
      *
      * @param TwigRendererInterface $renderer
      */
-    public function __construct(TwigRendererInterface $renderer)
+    public function __construct(FormRendererInterface $renderer)
     {
         $this->renderer = $renderer;
     }

--- a/Twig/Extension/FormExtension.php
+++ b/Twig/Extension/FormExtension.php
@@ -14,6 +14,7 @@ namespace Genemu\Bundle\FormBundle\Twig\Extension;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormRendererInterface;
 use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * FormExtension extends Twig with form capabilities.
@@ -46,8 +47,8 @@ class FormExtension extends AbstractExtension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('form_javascript', array($this, 'renderJavascript'), array('is_safe' => array('html'))),
-            new \Twig_SimpleFunction('form_stylesheet', null, array(
+            new TwigFunction('form_javascript', array($this, 'renderJavascript'), array('is_safe' => array('html'))),
+            new TwigFunction('form_stylesheet', null, array(
                 'is_safe' => array('html'),
                 'node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode',
             )),

--- a/Twig/Extension/FormExtension.php
+++ b/Twig/Extension/FormExtension.php
@@ -33,7 +33,7 @@ class FormExtension extends AbstractExtension
     /**
      * Constructs.
      *
-     * @param TwigRendererInterface $renderer
+     * @param FormRendererInterface $renderer
      */
     public function __construct(FormRendererInterface $renderer)
     {


### PR DESCRIPTION
Argument 1 passed to Genemu\Bundle\FormBundle\Twig\Extension\FormExtension::__construct() must be an instance of Symfony\Bridge\Twig\Form\TwigRendererInterface, instance of Symfony\Component\Form\FormRenderer given